### PR TITLE
Put project listing command in project CLI group

### DIFF
--- a/faculty_cli/cli.py
+++ b/faculty_cli/cli.py
@@ -369,14 +369,20 @@ def login():
     _populate_creds_file()
 
 
-@cli.command()
+@cli.group()
+def project():
+    """Manipulate Faculty projects."""
+    pass
+
+
+@project.command(name="list")
 @click.option(
     "-v",
     "--verbose",
     is_flag=True,
     help="Print extra information about projects.",
 )
-def projects(verbose):
+def list_projects(verbose):
     """List accessible Faculty projects."""
     _check_credentials()
     client = faculty_cli.casebook.Casebook()


### PR DESCRIPTION
@mociarain, @zblz and I discussed moving the `faculty projects`
subcommand to `faculty project list` for:

1. Consiststency with other resource types (e.g. `faculty server list`)
2. Extensibility in the future (e.g. `faculty project new`)

We decided to propose taking the CLI rename as an opportunity to remove
this historical inconsistency.